### PR TITLE
chore(deps): bump https://github.com/salaboy/demo-conference-site from 0.0.44 to 0.0.45

### DIFF
--- a/demo-conference/requirements.yaml
+++ b/demo-conference/requirements.yaml
@@ -7,8 +7,7 @@ dependencies:
   version: 0.0.66
 - name: demo-conference-site
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.44
+  version: 0.0.45
 - name: demo-conference-email
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.18
-

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,7 +2,7 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[salaboy/demo-conference-site](https://github.com/salaboy/demo-conference-site) |  | [0.0.44](https://github.com/salaboy/demo-conference-site/releases/tag/v0.0.44) | 
-[salaboy/demo-conference-agenda](https://github.com/salaboy/demo-conference-agenda) |  | [0.0.37](https://github.com/salaboy/demo-conference-agenda/releases/tag/v0.0.37) | 
-[salaboy/demo-conference-c4p](https://github.com/salaboy/demo-conference-c4p) |  | [0.0.66](https://github.com/salaboy/demo-conference-c4p/releases/tag/v0.0.66) | 
+[salaboy/demo-conference-site](https://github.com/salaboy/demo-conference-site) |  | [0.0.45](https://github.com/salaboy/demo-conference-site/releases/tag/v0.0.45) | 
+[salaboy/demo-conference-agenda](https://github.com/salaboy/conference-agenda) |  | [0.0.37](https://github.com/salaboy/conference-agenda/releases/tag/v0.0.37) | 
+[salaboy/demo-conference-c4p](https://github.com/salaboy/demo-conference-cp4) |  | [0.0.66](https://github.com/salaboy/demo-conference-c4p/releases/tag/v0.0.66) | 
 [salaboy/demo-conference-email](https://github.com/salaboy/demo-conference-email) |  | [0.0.18](https://github.com/salaboy/demo-conference-email/releases/tag/v0.0.18) | 

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -3,8 +3,8 @@ dependencies:
   owner: salaboy
   repo: demo-conference-site
   url: https://github.com/salaboy/demo-conference-site
-  version: 0.0.44
-  versionURL: https://github.com/salaboy/demo-conference-site/releases/tag/v0.0.44
+  version: 0.0.45
+  versionURL: https://github.com/salaboy/demo-conference-site/releases/tag/v0.0.45
 - host: github.com
   owner: salaboy
   repo: demo-conference-agenda


### PR DESCRIPTION
Update [salaboy/demo-conference-site](https://github.com/salaboy/demo-conference-site) from [0.0.44](https://github.com/salaboy/demo-conference-site/releases/tag/v0.0.44) to [0.0.45](https://github.com/salaboy/demo-conference-site/releases/tag/v0.0.45)

Command run was `jx step create pr chart --name demo-conference-site --version 0.0.45 --repo https://github.com/salaboy/demo-conference-app-chart.git`