### PR TITLE
chore(deps): bump https://github.com/salaboy/demo-conference-agenda from 0.0.37 to 0.0.38

### DIFF
--- a/demo-conference/requirements.yaml
+++ b/demo-conference/requirements.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - name: demo-conference-agenda
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.37
+  version: 0.0.38
 - name: demo-conference-c4p
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.66

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -3,6 +3,6 @@
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
 [salaboy/demo-conference-site](https://github.com/salaboy/demo-conference-site) |  | [0.0.45](https://github.com/salaboy/demo-conference-site/releases/tag/v0.0.45) | 
-[salaboy/demo-conference-agenda](https://github.com/salaboy/conference-agenda) |  | [0.0.37](https://github.com/salaboy/conference-agenda/releases/tag/v0.0.37) | 
+[salaboy/demo-conference-agenda](https://github.com/salaboy/demo-conference-agenda) |  | [0.0.38](https://github.com/salaboy/demo-conference-agenda/releases/tag/v0.0.38) | 
 [salaboy/demo-conference-c4p](https://github.com/salaboy/demo-conference-cp4) |  | [0.0.66](https://github.com/salaboy/demo-conference-c4p/releases/tag/v0.0.66) | 
 [salaboy/demo-conference-email](https://github.com/salaboy/demo-conference-email) |  | [0.0.18](https://github.com/salaboy/demo-conference-email/releases/tag/v0.0.18) | 

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -8,9 +8,9 @@ dependencies:
 - host: github.com
   owner: salaboy
   repo: demo-conference-agenda
-  url: https://github.com/salaboy/conference-agenda
-  version: 0.0.37
-  versionURL: https://github.com/salaboy/conference-agenda/releases/tag/v0.0.37
+  url: https://github.com/salaboy/demo-conference-agenda
+  version: 0.0.38
+  versionURL: https://github.com/salaboy/demo-conference-agenda/releases/tag/v0.0.38
 - host: github.com
   owner: salaboy
   repo: demo-conference-c4p


### PR DESCRIPTION
Update [salaboy/demo-conference-agenda](https://github.com/salaboy/demo-conference-agenda) from [0.0.37](https://github.com/salaboy/demo-conference-agenda/releases/tag/v0.0.37) to [0.0.38](https://github.com/salaboy/demo-conference-agenda/releases/tag/v0.0.38)

Command run was `jx step create pr chart --name demo-conference-agenda --version 0.0.38 --repo https://github.com/salaboy/demo-conference-app-chart.git`