### PR TITLE
chore(deps): bump https://github.com/salaboy/demo-conference-agenda from 0.0.39 to 0.0.40

### DIFF
--- a/demo-conference/requirements.yaml
+++ b/demo-conference/requirements.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - name: demo-conference-agenda
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.39
+  version: 0.0.40
 - name: demo-conference-c4p
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.66

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -3,6 +3,6 @@
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
 [salaboy/demo-conference-site](https://github.com/salaboy/demo-conference-site) |  | [0.0.45](https://github.com/salaboy/demo-conference-site/releases/tag/v0.0.45) | 
-[salaboy/demo-conference-agenda](https://github.com/salaboy/demo-conference-agenda) |  | [0.0.39](https://github.com/salaboy/demo-conference-agenda/releases/tag/v0.0.39) | 
+[salaboy/demo-conference-agenda](https://github.com/salaboy/demo-conference-agenda) |  | [0.0.40](https://github.com/salaboy/demo-conference-agenda/releases/tag/v0.0.40) | 
 [salaboy/demo-conference-c4p](https://github.com/salaboy/demo-conference-c4p) |  | [0.0.70](https://github.com/salaboy/demo-conference-c4p/releases/tag/v0.0.70) | 
 [salaboy/demo-conference-email](https://github.com/salaboy/demo-conference-email) |  | [0.0.19](https://github.com/salaboy/demo-conference-email/releases/tag/v0.0.19) | 

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -9,8 +9,8 @@ dependencies:
   owner: salaboy
   repo: demo-conference-agenda
   url: https://github.com/salaboy/demo-conference-agenda
-  version: 0.0.39
-  versionURL: https://github.com/salaboy/demo-conference-agenda/releases/tag/v0.0.39
+  version: 0.0.40
+  versionURL: https://github.com/salaboy/demo-conference-agenda/releases/tag/v0.0.40
 - host: github.com
   owner: salaboy
   repo: demo-conference-c4p


### PR DESCRIPTION
Update [salaboy/demo-conference-agenda](https://github.com/salaboy/demo-conference-agenda) from [0.0.39](https://github.com/salaboy/demo-conference-agenda/releases/tag/v0.0.39) to [0.0.40](https://github.com/salaboy/demo-conference-agenda/releases/tag/v0.0.40)

Command run was `jx step create pr chart --name demo-conference-agenda --version 0.0.40 --repo https://github.com/salaboy/demo-conference-app-chart.git`