### PR TITLE
chore(deps): bump https://github.com/salaboy/demo-conference-c4p to 0.0.71

### DIFF
--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -4,5 +4,5 @@ Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
 [salaboy/demo-conference-site](https://github.com/salaboy/demo-conference-site) |  | [0.0.45](https://github.com/salaboy/demo-conference-site/releases/tag/v0.0.45) | 
 [salaboy/demo-conference-agenda](https://github.com/salaboy/demo-conference-agenda) |  | [0.0.40](https://github.com/salaboy/demo-conference-agenda/releases/tag/v0.0.40) | 
-[salaboy/demo-conference-c4p](https://github.com/salaboy/demo-conference-c4p) |  | [0.0.70](https://github.com/salaboy/demo-conference-c4p/releases/tag/v0.0.70) | 
+[salaboy/demo-conference-c4p](https://github.com/salaboy/demo-conference-c4p) |  | [0.0.71](https://github.com/salaboy/demo-conference-c4p/releases/tag/v0.0.71) | 
 [salaboy/demo-conference-email](https://github.com/salaboy/demo-conference-email) |  | [0.0.19](https://github.com/salaboy/demo-conference-email/releases/tag/v0.0.19) | 

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -15,8 +15,8 @@ dependencies:
   owner: salaboy
   repo: demo-conference-c4p
   url: https://github.com/salaboy/demo-conference-c4p
-  version: 0.0.70
-  versionURL: https://github.com/salaboy/demo-conference-c4p/releases/tag/v0.0.70
+  version: 0.0.71
+  versionURL: https://github.com/salaboy/demo-conference-c4p/releases/tag/v0.0.71
 - host: github.com
   owner: salaboy
   repo: demo-conference-email


### PR DESCRIPTION
Update [salaboy/demo-conference-c4p](https://github.com/salaboy/demo-conference-c4p) to [0.0.71](https://github.com/salaboy/demo-conference-c4p/releases/tag/v0.0.71)

Command run was `jx step create pr chart --name demo-conference-cp4 --version 0.0.71 --repo https://github.com/salaboy/demo-conference-app-chart.git`