### PR TITLE
chore(deps): bump https://github.com/salaboy/demo-conference-c4p to 0.0.74

### DIFF
--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -4,5 +4,5 @@ Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
 [salaboy/demo-conference-site](https://github.com/salaboy/demo-conference-site) |  | [0.0.46](https://github.com/salaboy/demo-conference-site/releases/tag/v0.0.46) | 
 [salaboy/demo-conference-agenda](https://github.com/salaboy/demo-conference-agenda) |  | [0.0.41](https://github.com/salaboy/demo-conference-agenda/releases/tag/v0.0.41) | 
-[salaboy/demo-conference-c4p](https://github.com/salaboy/demo-conference-c4p) |  | [0.0.73](https://github.com/salaboy/demo-conference-c4p/releases/tag/v0.0.73) | 
+[salaboy/demo-conference-c4p](https://github.com/salaboy/demo-conference-c4p) |  | [0.0.74](https://github.com/salaboy/demo-conference-c4p/releases/tag/v0.0.74) | 
 [salaboy/demo-conference-email](https://github.com/salaboy/demo-conference-email) |  | [0.0.19](https://github.com/salaboy/demo-conference-email/releases/tag/v0.0.19) | 

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -15,8 +15,8 @@ dependencies:
   owner: salaboy
   repo: demo-conference-c4p
   url: https://github.com/salaboy/demo-conference-c4p
-  version: 0.0.73
-  versionURL: https://github.com/salaboy/demo-conference-c4p/releases/tag/v0.0.73
+  version: 0.0.74
+  versionURL: https://github.com/salaboy/demo-conference-c4p/releases/tag/v0.0.74
 - host: github.com
   owner: salaboy
   repo: demo-conference-email


### PR DESCRIPTION
Update [salaboy/demo-conference-c4p](https://github.com/salaboy/demo-conference-c4p) to [0.0.74](https://github.com/salaboy/demo-conference-c4p/releases/tag/v0.0.74)

Command run was `jx step create pr chart --name demo-conference-cp4 --version 0.0.74 --repo https://github.com/salaboy/demo-conference-app-chart.git`