### PR TITLE
chore(deps): bump https://github.com/salaboy/demo-conference-email from 0.0.19 to 0.0.20

### DIFF
--- a/demo-conference/requirements.yaml
+++ b/demo-conference/requirements.yaml
@@ -10,4 +10,4 @@ dependencies:
   version: 0.0.46
 - name: demo-conference-email
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.19
+  version: 0.0.20

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -5,4 +5,4 @@ Dependency | Sources | Version | Mismatched versions
 [salaboy/demo-conference-site](https://github.com/salaboy/demo-conference-site) |  | [0.0.46](https://github.com/salaboy/demo-conference-site/releases/tag/v0.0.46) | 
 [salaboy/demo-conference-agenda](https://github.com/salaboy/demo-conference-agenda) |  | [0.0.42](https://github.com/salaboy/demo-conference-agenda/releases/tag/v0.0.42) | 
 [salaboy/demo-conference-c4p](https://github.com/salaboy/demo-conference-c4p) |  | [0.0.74](https://github.com/salaboy/demo-conference-c4p/releases/tag/v0.0.74) | 
-[salaboy/demo-conference-email](https://github.com/salaboy/demo-conference-email) |  | [0.0.19](https://github.com/salaboy/demo-conference-email/releases/tag/v0.0.19) | 
+[salaboy/demo-conference-email](https://github.com/salaboy/demo-conference-email) |  | [0.0.20](https://github.com/salaboy/demo-conference-email/releases/tag/v0.0.20) | 

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -21,5 +21,5 @@ dependencies:
   owner: salaboy
   repo: demo-conference-email
   url: https://github.com/salaboy/demo-conference-email
-  version: 0.0.19
-  versionURL: https://github.com/salaboy/demo-conference-email/releases/tag/v0.0.19
+  version: 0.0.20
+  versionURL: https://github.com/salaboy/demo-conference-email/releases/tag/v0.0.20


### PR DESCRIPTION
Update [salaboy/demo-conference-email](https://github.com/salaboy/demo-conference-email) from [0.0.19](https://github.com/salaboy/demo-conference-email/releases/tag/v0.0.19) to [0.0.20](https://github.com/salaboy/demo-conference-email/releases/tag/v0.0.20)

Command run was `jx step create pr chart --name demo-conference-email --version 0.0.20 --repo https://github.com/salaboy/demo-conference-app-chart.git`